### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-Fork from: [JoshuaRileyDev/mac-apps-launcher](https://github.com/JoshuaRileyDev/mac-apps-launcher)
-
 # Mac Apps Launcher MCP Server
 
 A Model Context Protocol (MCP) server for launching and managing macOS applications.
+
+<a href="https://glama.ai/mcp/servers/@eugenechen0514/mac-apps-launcher">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@eugenechen0514/mac-apps-launcher/badge" alt="mac-apps-launcher MCP server" />
+</a>
 
 ## Features
 


### PR DESCRIPTION
This PR adds a badge for the [mac-apps-launcher](https://glama.ai/mcp/servers/@eugenechen0514/mac-apps-launcher) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@eugenechen0514/mac-apps-launcher">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@eugenechen0514/mac-apps-launcher/badge" alt="mac-apps-launcher MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.